### PR TITLE
Fix threading issues and misc improvements

### DIFF
--- a/src/hxcodec/openfl/Video.hx
+++ b/src/hxcodec/openfl/Video.hx
@@ -218,7 +218,7 @@ class Video extends Bitmap
 		super(bitmapData, AUTO, true);
 
 		events = new Array<Bool>();
-		for (i in 0...9)
+		for (i in 0...10)
 			events[i] = false;
 
 		onOpening = new Event<Void->Void>();
@@ -341,7 +341,8 @@ class Video extends Bitmap
 
 		pixelsMutex.release();
 
-		events.splice(0, events.length);
+		for (i in 0...10)
+			events[i] = false;
 
 		if (instance != null)
 		{

--- a/src/hxcodec/openfl/Video.hx
+++ b/src/hxcodec/openfl/Video.hx
@@ -330,11 +330,16 @@ class Video extends Bitmap
 			texture = null;
 		}
 
+		pixelsMutex.acquire();
+		
 		videoWidth = 0;
 		videoHeight = 0;
 
 		untyped __cpp__('delete this->pixels;');
 		pixels = null;
+		frameReady = false;
+
+		pixelsMutex.release();
 
 		events.splice(0, events.length);
 

--- a/src/hxcodec/openfl/Video.hx
+++ b/src/hxcodec/openfl/Video.hx
@@ -332,6 +332,8 @@ class Video extends Bitmap
 
 		videoWidth = 0;
 		videoHeight = 0;
+
+		untyped __cpp__('delete this->pixels;');
 		pixels = null;
 
 		events.splice(0, events.length);

--- a/src/hxcodec/openfl/Video.hx
+++ b/src/hxcodec/openfl/Video.hx
@@ -110,6 +110,7 @@ static void logging(void *data, int level, const libvlc_log_t *ctx, const char *
 	}
 	#else
 	vprintf(fmt, args);
+	printf("\\n");
 	#endif
 }')
 class Video extends Bitmap


### PR DESCRIPTION
This attempts to fix various threading-related issues in hxcodec.openfl.Video.

libvlc callbacks and decoding happen on multiple threads, so any haxe<->c++ interaction needs to be thread safe. In particular, the buffer to hold the decoded pixels was allocated in C++ on a separate thread, and there was no synchronization when using it on the main Haxe thread.

At best, this would cause visual tearing as a partially decoded frame is uploaded:

<img width="877" alt="image" src="https://github.com/FunkinCrew/hxCodec/assets/36278/b486f1df-5408-468e-b639-c05dc0ce1b16">

At worst, this can cause race conditions and crashes. Specifically the `format_setup` callback may be called multiple times as libvlc tries different decoders. For example, I get this when trying to play an MP4 with `-DHXC_LIBVLC_LOGGING`:

```
...
format_setup called!
...
1920x1080 (1920x1088) chroma: I420 -> 1920x1088 (1920x1088) chroma: RV32 with scaling using Bicubic (good quality)
...
original format sz 1920x1088, of (0,0), vsz 1920x1080, 4cc DX11, sar 1:1, msk r0x0 g0x0 b0x0
looking for hw decoder module matching "none": 2 candidates
no hw decoder modules matched
trying format dxva2_vld
...
format_setup called!
...
A filter to adapt decoder DXA9 to display RV32 is needed
...
looking for hw decoder module matching "none": 2 candidates
no hw decoder modules matched
format_setup called!
...
A filter to adapt decoder I420 to display RV32 is needed
looking for video converter module matching "any": 24 candidates
...
auto hiding mouse cursor
```

This is before the first frame is decoded, so the `pixels` buffer was being reallocated multiple times on the decoding thread. In the meantime, the main Haxe thread could try to upload it with `texture.uploadFromByteArray`, which will explode if the buffer was deleted while being uploaded. On my machine, this crashed in a debug build ~75% of the time

This PR contains multiple improvements:

* Use `sys.thread.Mutex` around all pixel buffer operations to ensure one thread operates on it at a time. This fixes the crashes and tearing.
* Defer OpenFL texture creation until the first frame starts decoding. This prevents multiple `format_setup` calls from reallocating the pixel buffer unnecessarily.
* Use the libvlc `display` callback to determine when to show the next frame instead of using a 120hz timer. This avoids unnecessary texture uploads when the frame hasn't changed.
* Delete the pixel buffer when the video is disposed. Previously this would leak memory.

Possible improvement: Use atomics for the event bools.