### PR TITLE
Create the asset library `vlc` only on `Windows` and `MacOS`.

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension xmlns="https://lime.openfl.org/project/1.0.4" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://lime.openfl.org/project/1.0.4 https://lime.openfl.org/xsd/project-1.0.4.xsd">
 
-	<!-- Using a custom asset library so we don't clutter `default` -->
-	<library name="vlc" preload="false" />
-	<assets path="project/vlc/dll/Windows" rename="" if="windows" library="vlc" />
-	<assets path="project/vlc/dll/MacOS" rename="../MacOS" if="mac" library="vlc" />
+	<section if="windows || mac">
+		<!-- Using a custom asset library so we don't clutter `default` -->
+		<library name="vlc" preload="false" />
+
+		<assets path="project/vlc/dll/Windows" rename="" if="windows" library="vlc" />
+		<assets path="project/vlc/dll/MacOS" rename="../MacOS" if="mac" library="vlc" />
+	</section>
 
 	<section if="android">
 		<ndll name="c++_shared" dir="project/vlc/lib" />


### PR DESCRIPTION
It causes issues on Linux and Android when using polymod with this blank asset library.